### PR TITLE
Title and story

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -11,9 +11,9 @@ class StoriesController < ApplicationController
 
     if @prompt.valid?
       story_generator = StoryGenerator.new
-      generated_story = story_generator.generate_story(@prompt)
-      @story = Story.create(user_id: @user.id, title: generated_story.partition("#").first.strip,
-      content: generated_story.partition("#").last.strip)
+      title_and_story = story_generator.generate_story(@prompt)
+      @story = Story.create(user_id: @user.id, title: title_and_story[:title],
+                            content: title_and_story[:story])
       redirect_to story_path(@story)
     else
       render :new

--- a/app/javascript/controllers/oval_controller.js
+++ b/app/javascript/controllers/oval_controller.js
@@ -9,9 +9,9 @@ export default class extends Controller {
     console.log(this.buttonTarget);
   }
 
-  // loading() {
-  //   this.containerTarget.classList.add("hidden-content")
-  //   this.spinnerTarget.classList.add("display-spinner")
-  // }
+  loading() {
+    this.containerTarget.classList.add("hidden-content")
+    this.spinnerTarget.classList.add("display-spinner")
+  }
 
 }

--- a/app/services/story_generator.rb
+++ b/app/services/story_generator.rb
@@ -5,9 +5,16 @@ class StoryGenerator
     request = "Tell me a story of maximum 250 words in #{prompt.language}. The protagonist is #{prompt.protagonist},
     and the story is set in #{prompt.setting}. His mortal enemy is #{prompt.enemy}, and his/her favorite food is #{prompt.food}.
     Start with a title, something like 'Arthur and the dark forest'. Put a # at the end of the title."
+
     response = $open_ai_client.chat(parameters: { model: "gpt-3.5-turbo", messages: [{ role: "user", content: request }],
                                                   temperature: 0.7 })
     generated_story = response.dig("choices", 0, "message", "content")
+    extract_title_and_story(generated_story)
   end
 
+  def extract_title_and_story(generated_story)
+    title_and_story = { title: generated_story.partition("#").first.strip,
+                        story: generated_story.partition("#").last.strip }
+    title_and_story
+  end
 end

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -6,7 +6,7 @@
     </div>
 
   <div class="stories-form">
-    <%= simple_form_for [@prompt], url: stories_path, html: { data: {turbo: false, oval_target: "container" }, class: "stories-form" } do |f| %>
+    <%= simple_form_for [@prompt], url: stories_path, html: { data: { turbo: false, oval_target: "container" }, class: "stories-form" } do |f| %>
     <p>Ciao! Please answer my questions so I can generate an original story for you.</p>
     <%= f.input :protagonist, label: "What's the protagonist's name?" %>
     <%= f.input :food, label: "What food do they love?" %>


### PR DESCRIPTION
Add method extract_title_and_story to Story Generator
The method separates title and story itself from chatGPT's response and sends them as a hash to the controller. This removes string manipulation from the controller. 