### PR TITLE
Error handling in Story Generator

### DIFF
--- a/app/services/story_generator.rb
+++ b/app/services/story_generator.rb
@@ -3,12 +3,19 @@ class StoryGenerator
 
   def generate_story(prompt)
     request = request(prompt)
-    response = $open_ai_client.chat(parameters: { model: "gpt-3.5-turbo",
+
+    begin
+      response = $open_ai_client.chat(parameters: { model: "gpt-3.5-turbo",
                                                   messages: [{ role: "user",
                                                   content: request }],
                                                   temperature: 0.7 })
-    response_content = response.dig("choices", 0, "message", "content")
-    extract_title_and_story(response_content)
+      response_content = response.dig("choices", 0, "message", "content")
+      extract_title_and_story(response_content)
+    rescue StandardError => e
+      Rails.logger.error("Error generating story: #{e.message}")
+      { title: nil, body: nil }
+    end
+
   end
 
   def extract_title_and_story(response_content)


### PR DESCRIPTION
- Add begin end block with rescue statements to catch errors in API call and handle them gracefully.
- At the moment errors are caught, the method returns a hash with values of nil for title and body.
- The controller raises an active record error, which is rescued and notifies the user of a problem with generating the story.